### PR TITLE
ARCH-1002 - Updates to action

### DIFF
--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -1,13 +1,13 @@
 name: Increment Version on Merge
-on: 
+on:
   pull_request:
     types: [closed]
 
 jobs:
   increment-version:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
-    
-    runs-on: [ubuntu-20.04]
+
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout Repository
@@ -17,16 +17,13 @@ jobs:
 
       - name: Increment the version
         uses: actions/github-script@v4
-        with: 
+        with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const util = require('util');
-            const exec = util.promisify(require('child_process').exec);
-
             let newTag;
             try {
-              ({ stdout: tag } = await exec(`git describe --tags --abbrev=0`));
-
+              let tag = '';
+              await exec.exec(`git describe --tags --abbrev=0`, [], { listeners: { stdout: (data) => { tag += data.toString(); } } });
               tag = tag.replace('\n', '').trim();
               core.info(`The latest tag is: ${tag}`);
               const majorMinorPatch = tag.split('.');
@@ -39,11 +36,10 @@ jobs:
               core.info('An error occurred getting the tags for the repo.  It most likely does not have any tags to use. Defaulting to v1.0.0.');
               core.info(error);
             }
-
             core.info(`Pushing tag '${newTag}' to the repository...`)
             await github.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: `refs/tags/${newTag}`,
               sha: context.sha
-            });      
+            });

--- a/README.md
+++ b/README.md
@@ -1,49 +1,81 @@
 # workflow-conclusion
 
-This action will examine the outcome for each completed job in a workflow run to output a single outcome for the workflow.
+This action will: 
+1. Use the [Actions REST API] to get the conclusion for each previous job.
+   - The API call provides the `conclusion` which is the job status after `continue-on-error` is applied.
+   - In addition to jobs, the API call also includes status check results.
+2. Examine each additional conclusion that is provided through the `additional-conclusions` argument.  
+3. Determine a single workflow conclusion based on the API results and arguments.  
 
-The conclusion is determined by:
- - First looking for any Skipped jobs and if found the conclusion is set to `skipped`
- - Then looking for any Cancelled jobs and if found the conclusion is set to `cancelled`
- - Then looking for any Failed jobs and if found the conclusion is set to `failure`
- - Finally looking for any Successful jobs and if found the conclusion is set to `success`
- - If none of the statuses are found, it will set the conclusion to the fallback value which defaults to `skipped`
+The action will interpret a wider range of inputs in the `additional-conclusions` argument than the standard GitHub values of *cancelled, skipped, failure and success*.  This allows using the `outcome` of a step as well as the output that an action might set.
+- `[cancelled | canceled | cancel]` are accepted and interpreted as `cancelled`
+- `[skipped | skip]` are accepted and interpreted as `skipped`
+- `[failure| failing| failed| fail]` are accepted and interpreted as `failure`
+- `[success| passing| passed| pass]` are accepted and interpreted as `success`
+  
+The final workflow conclusion is determined by:
+ - First looking for any Cancelled conclusions and if found the conclusion is set to `cancelled`
+ - Then looking for any Skipped conclusions and if found the conclusion is set to `skipped`
+ - Then looking for any Failed conclusions and if found the conclusion is set to `failure`
+ - Finally looking for any Successful conclusions and if found the conclusion is set to `success`
+ - If none of the statuses are found, it will set the workflow conclusion to the fallback value which defaults to `skipped`
+
 
 ## Inputs
-| Parameter             | Is Required | Description                                                                         |
-| --------------------- | ----------- | ----------------------------------------------------------------------------------- |
-| `github-token`        | true        | The token used to make API requests                                                 |
-| `fallback-conclusion` | false       | The fallback conclusion to use when one cannot be determined.  Defaults to skipped. |
+| Parameter                | Is Required | Description                                                                                                                                                                                                                                                                                                     |
+| ------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `github-token`           | true        | The token used to make API requests                                                                                                                                                                                                                                                                             |
+| `additional-conclusions` | false       | A JSON-parseable array of additional conclusions to consider.  See the comments above for accepted values.  See the [Usage Example](#usage) below for the correct format.  <br/><br/>This may be helpful if `continue-on-error` is used on a steps or for actions that provide an output with their own status. |
+| `fallback-conclusion`    | false       | The fallback conclusion to use when one cannot be determined.  Defaults to skipped.                                                                                                                                                                                                                             |
 
 ## Outputs
-| Output       | Description              |
-| ------------ | ------------------------ |
-| `conclusion` | The workflow conclusion. |
+| Output                | Description              |
+| --------------------- | ------------------------ |
+| `workflow-conclusion` | The workflow conclusion. |
 
-## Example
+## Usage
 
 ```yml
 jobs:
-  approve:
+  ...
+  
+  test:
     runs-on: [ubuntu-20.04]
+    outputs: 
+      test-step-outcome: ${{ steps.test.outcome }}             # Can be: cancelled, skipped, failure, success
+      test-check-result: ${{ steps.test_check.test-outcome }}  # Can be:  Failed, Passed
     steps:
-      run: check-for-approval.sh
-
-  deploy:
-    runs-on: [ubuntu-20.04]
-    steps:
-      run: deploy-the-code.sh
+      - name: dotnet test with coverage
+        id: test
+        continue-on-error: true
+        run: dotnet test --logger trx --configuration Release /property:CollectCoverage=True /property:CoverletOutputFormat=opencover
+      
+      - name: Process dotnet test results and create a status check
+        id: test_check
+        uses: im-open/process-dotnet-test-results@v1.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          
+  ...
 
   update-deployment-board:
     runs-on: [ubuntu-20.04]
-    needs: [approval, deploy]
+    needs: [test, auto-deploy-to-dev]
     if: always()
     steps:
-      - uses: im-open/workflow-conclusion@v1.0.0
+      - uses: im-open/workflow-conclusion@v1.0.1
         id: conclusion
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # needs.test.outputs.test-step-outcome is step status before continue-on-error is applied.  Could be cancelled, skipped, failure, success.
+          # needs.test.outputs.test-check-result is an output of the process-dotnet-test-results action.  Could be Failed or Passed
+          additional-conclusions: |
+            [
+              { "name": "dotnet-test-coverage", "conclusion" : "${{ needs.test.outputs.test-step-outcome }}" }, 
+              { "name": "process-test-results", "conclusion" : "${{ needs.test.outputs.test-check-result }}" }
+            ]
       
+      # Use the workflow conclusion below
       - name: Update Deployment Board
         uses: im-open/update-deployment-board@v1.0.1
         with:
@@ -51,7 +83,7 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           board-number: 1
           ref: ${{ github.event.inputs.branch-tag-sha }}
-          deploy-status: ${{ env.WORKFLOW_CONCLUSION }} # can also use ${{ steps.conclusion.conclusion }}
+          deploy-status: ${{ env.WORKFLOW_CONCLUSION }} # can also use ${{ steps.conclusion.workflow-conclusion }}
 ```
 
 ## Recompiling
@@ -76,3 +108,5 @@ This project has adopted the [im-open's Code of Conduct](https://github.com/im-o
 ## License
 
 Copyright &copy; 2021, Extend Health, LLC. Code released under the [MIT license](LICENSE).
+
+[Actions REST API]: https://docs.github.com/en/rest/reference/actions#list-jobs-for-a-workflow-run

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,13 @@ inputs:
     description: 'The fallback conclusion to use'
     required: false
     default: skipped
+  additional-conclusions:
+    description: 'A JSON-parseable array of additional conclusions to consider.'
+    required: false
+    default: ''
 
 outputs:
-  conclusion:
+  workflow-conclusion:
     description: Workflow conclusion
 
 runs:

--- a/main.js
+++ b/main.js
@@ -18,12 +18,13 @@ async function getJobOutcomes() {
       return [];
     }
     let outcomes = [];
+    core.info('\nIndividual Job Statuses:');
     response.data.jobs.forEach(j => {
       if (j.conclusion) {
-        core.info(`${j.name}: ${j.conclusion}`);
+        core.info(`\t${j.name}: ${j.conclusion}`);
         outcomes.push(j.conclusion.toLowerCase());
       } else {
-        core.info(`${j.name} has not concluded yet.`);
+        core.info(`\t${j.name}: Has not concluded yet.`);
       }
     });
     return outcomes;
@@ -32,27 +33,80 @@ async function getJobOutcomes() {
   }
 }
 
+function processAdditionalOutcomes(outcomes) {
+  let additionalConclusionsRaw = core.getInput('additional-conclusions');
+  let additionalConclusions = JSON.parse(additionalConclusionsRaw);
+  const willNotContribute = 'This conclusion will not contribute to the final workflow conclusion.';
+  core.info('\nAdditional Conclusions:');
+
+  additionalConclusions.forEach(ac => {
+    const cleanConclusion = ac.conclusion.toLowerCase().trim();
+    switch (cleanConclusion) {
+      case 'failing':
+      case 'failed':
+      case 'failure':
+      case 'fail':
+        outcomes.push('failure');
+        core.warning(`\t${ac.name}: ${ac.conclusion} => failure`);
+        break;
+      case 'passing':
+      case 'passed':
+      case 'pass':
+      case 'success':
+        outcomes.push('success');
+        core.info(`\t${ac.name}: ${ac.conclusion} => success`);
+        break;
+      case 'cancelled':
+      case 'canceled':
+      case 'cancel':
+        outcomes.push('cancelled');
+        core.warning(`${ac.name}: ${ac.conclusion} => cancelled`);
+        break;
+      case 'skipped':
+      case 'skip':
+        outcomes.push('skipped');
+        core.warning(`${ac.name}: ${ac.conclusion} => skipped`);
+        break;
+      case '':
+        core.warning(
+          `${ac.name} appears to be empty because the step may not have been run.  ${willNotContribute}`
+        );
+        break;
+      default:
+        core.warning(
+          `${ac.name} has an unknown option (${cleanConclusion}).  ${willNotContribute}`
+        );
+        break;
+    }
+  });
+}
+
 async function run() {
-  const outcomes = await getJobOutcomes();
+  let outcomes = await getJobOutcomes();
+  processAdditionalOutcomes(outcomes);
 
   const fallback = core.getInput('fallback-conclusion');
   let conclusion = fallback;
 
-  // Skipped seems to be the outcome when it is cancelled, so check for that first.
-  // Then if there are any failures set it as a failure, otherwise it will most
-  // likely be success.
-  if (outcomes.includes('skipped')) {
-    conclusion = 'skipped';
-  } else if (outcomes.includes('cancelled')) {
+  // Skipped seems to be the outcome when it is cancelled sometimes, so check
+  // for that right after the cancelled type. Then if there are any failures set
+  // it as a failure, otherwise it will most likely be success.
+  if (outcomes.includes('cancelled')) {
     conclusion = 'cancelled';
+  } else if (outcomes.includes('skipped')) {
+    conclusion = 'skipped';
   } else if (outcomes.includes('failure')) {
     conclusion = 'failure';
   } else if (outcomes.includes('success')) {
     conclusion = 'success';
   }
-  core.info(`The workflow outcome to this point is: ${conclusion}`);
-  core.setOutput('conclusion', conclusion);
+  core.info(`\nThe workflow outcome to this point is: ${conclusion}`);
+  core.setOutput('workflow_conclusion', conclusion);
   core.exportVariable('WORKFLOW_CONCLUSION', conclusion);
+
+  core.info(`The outputs have been set`);
+  core.info(`\tsteps.step-id.workflow_conclusion = ${conclusion}`);
+  core.info(`\tenv.WORKFLOW_CONCLUSION = ${conclusion}`);
 }
 
 run();


### PR DESCRIPTION
- Add an additional-conclusions argument so more items can be passed in to evaluate.
- Rename the output to workflow_conclusion
- Formatting of each job status
- Amend the order of the status checks (cancelled, skipped, failure, success)
- Adding additional logging around the outputs
- Update the readme with examples
